### PR TITLE
Fix Type Error in Extended Mode Options Handling

### DIFF
--- a/src/params_parser.ts
+++ b/src/params_parser.ts
@@ -274,6 +274,14 @@ export class ParamsParser {
     // 拡張モード時は値をそのままセット（型安全性はテストで担保）
     if (this.config.isExtendedMode) {
       const options = this.parseOptions(args);
+      if ('error' in options) {
+        return {
+          type: 'double',
+          demonstrativeType: normalizedDemonstrativeType as DemonstrativeType,
+          layerType: normalizedLayerType as LayerType,
+          error: options.error,
+        };
+      }
       return {
         type: 'double',
         demonstrativeType: normalizedDemonstrativeType as DemonstrativeType,


### PR DESCRIPTION
# Fix Type Error in Extended Mode Options Handling

## Overview
This PR fixes a type error in the extended mode options handling of the `ParamsParser` class. The fix ensures proper type safety and error handling when processing options in extended mode.

## Changes
- Add proper error handling for options in extended mode
  - Check for error in options before returning
  - Return appropriate error response when options contain an error
  - Fix type compatibility issue between `OptionParams` and error object

## Testing
- All tests pass
- Type checking passes
- Extended mode functionality works as expected

## Related Issues
Closes #6 