### PR TITLE
Add --config option for DoubleParams

### DIFF
--- a/docs/glossary.ja.md
+++ b/docs/glossary.ja.md
@@ -62,6 +62,7 @@
 | --destination | -o         | 出力ファイルパス。結果の保存先を指定。パスの存在確認は行わない。                     | [options.ja.md](options.ja.md) |
 | --input       | -i         | 入力レイヤータイプ。処理の入力元となる層を指定。LayerTypeの値のみを許可。            | [options.ja.md](options.ja.md) |
 | --adaptation  | -a         | プロンプト適応タイプ。処理の挙動を調整するために使用。カスタマイズ可能な動作を指定。 | [options.ja.md](options.ja.md) |
+| --config      | -c         | 設定ファイル名。DoubleParamsでのみ使用可能。処理の設定を外部ファイルから読み込む。   | [options.ja.md](options.ja.md) |
 
 ## 拡張機能関連
 

--- a/docs/options.ja.md
+++ b/docs/options.ja.md
@@ -12,6 +12,7 @@
 | --destination | -o         | 出力ファイルパス     | string  | いいえ | `--destination output.md` |
 | --input       | -i         | 入力レイヤータイプ   | enum    | いいえ | `--input project`         |
 | --adaptation  | -a         | プロンプト適応タイプ | string  | いいえ | `--adaptation strict`     |
+| --config      | -c         | 設定ファイル名       | string  | いいえ | `--config test`           |
 
 ## オプションの制約
 
@@ -26,6 +27,10 @@
 3. **無効なオプション**
    - 未定義のオプションはエラーなしで無視されます
    - ファイルパスに対する検証は行われません
+
+4. **パラメータタイプによる制約**
+   - `--config` / `-c` オプションは DoubleParams でのみ使用可能です
+   - 他のパラメータタイプ（NoParams, SingleParam）では無視されます
 
 ## 入力レイヤータイプの値
 
@@ -71,4 +76,6 @@ breakdown summary task -a strict
 
 ```bash
 breakdown to issue --from input.md -o output.md -i project -a strict
+breakdown to project --config test
+breakdown summary task -c test
 ```

--- a/docs/params.ja.md
+++ b/docs/params.ja.md
@@ -72,6 +72,8 @@ breakdown init
 breakdown to project
 breakdown summary issue
 breakdown defect task
+breakdown to project --config test
+breakdown summary task -c test
 ```
 
 ## エラーケース
@@ -81,3 +83,4 @@ breakdown defect task
 | 引数過多                | "Too many arguments. Maximum 2 arguments are allowed." |
 | 不正なDemonstrativeType | "Invalid value for demonstrativeType: {value}"         |
 | 不正なLayerType         | "Invalid value for layerType: {value}"                 |
+| 不正なConfig使用        | "Config option is only available with DoubleParams"    |

--- a/examples/README.md
+++ b/examples/README.md
@@ -63,6 +63,31 @@ deno run options_usage.ts to issue -f input.md -o output.md -i project
 deno run options_usage.ts to issue --from input.md -o output.md --input project
 ```
 
+## Config Option Usage (`config_usage.ts`)
+
+Demonstrates the usage of the config option:
+
+- Long and short form config options
+- Config option with other options
+- Config option behavior in different modes
+
+```bash
+# Using config option with long form
+deno run config_usage.ts to project --config test
+
+# Using config option with short form
+deno run config_usage.ts to project -c test
+
+# Using config with other options
+deno run config_usage.ts to project --config test --from input.md --destination output.md
+
+# Config option is ignored in single param mode
+deno run config_usage.ts init --config test
+
+# Config option is ignored in no params mode
+deno run config_usage.ts --config test
+```
+
 ## Extended Parameters Usage (`extended_params_usage.ts`)
 
 Shows how to use custom parameter validation with extended mode:

--- a/examples/config_usage.ts
+++ b/examples/config_usage.ts
@@ -86,4 +86,4 @@ if (result.type === 'double') {
   console.log('Please provide both command and layer type.');
   console.log('\nFor usage information, run: config_usage --help');
   Deno.exit(1);
-} 
+}

--- a/examples/config_usage.ts
+++ b/examples/config_usage.ts
@@ -1,0 +1,89 @@
+import { ParamsParser } from '../mod.ts';
+
+const parser = new ParamsParser();
+const result = parser.parse(Deno.args);
+
+// Helper function to display usage
+function showUsage() {
+  console.log(`
+Usage: config_usage <command> <layer> [options]
+
+Commands:
+  to, summary, defect
+
+Layers:
+  project, issue, task (and their aliases)
+
+Options:
+  --config, -c <name>        Configuration file name (without extension)
+  --from, -f <file>          Input file path
+  --destination, -o <file>    Output file path
+  --input, -i <layer>        Input layer type
+
+Examples:
+  # Using config option with long form
+  config_usage to project --config test
+
+  # Using config option with short form
+  config_usage to project -c test
+
+  # Using config with other options
+  config_usage to project --config test --from input.md --destination output.md
+
+  # Config option is ignored in single param mode
+  config_usage init --config test
+
+  # Config option is ignored in no params mode
+  config_usage --config test
+`);
+}
+
+// Display help if requested
+if (result.type === 'no-params' && result.help) {
+  showUsage();
+  Deno.exit(0);
+}
+
+// Handle any errors
+if ('error' in result && result.error) {
+  console.error(`Error: ${result.error}`);
+  console.log('\nFor usage information, run: config_usage --help');
+  Deno.exit(1);
+}
+
+// Process valid command
+if (result.type === 'double') {
+  const { demonstrativeType, layerType, options = {} } = result;
+
+  console.log('Command processed successfully:');
+  console.log('----------------------------');
+  console.log(`Action: ${demonstrativeType} ${layerType}`);
+
+  if (options?.configFile) {
+    console.log(`Configuration: ${options.configFile}`);
+  }
+  if (options?.fromFile) {
+    console.log(`Input file: ${options.fromFile}`);
+  }
+  if (options?.destinationFile) {
+    console.log(`Output file: ${options.destinationFile}`);
+  }
+  if (options?.fromLayerType) {
+    console.log(`Converting from layer: ${options.fromLayerType}`);
+  }
+} else if (result.type === 'single') {
+  console.log('Config option is ignored in single param mode');
+  console.log(`Command: ${result.command}`);
+} else if (result.type === 'no-params') {
+  console.log('Config option is ignored in no params mode');
+  if (result.help) {
+    console.log('Help requested');
+  }
+  if (result.version) {
+    console.log('Version requested');
+  }
+} else {
+  console.log('Please provide both command and layer type.');
+  console.log('\nFor usage information, run: config_usage --help');
+  Deno.exit(1);
+} 

--- a/examples/extended_params_usage.ts
+++ b/examples/extended_params_usage.ts
@@ -41,4 +41,4 @@ if (result.type === 'double') {
   if (result.version) {
     console.log('Version requested');
   }
-} 
+}

--- a/src/params_parser.ts
+++ b/src/params_parser.ts
@@ -118,6 +118,8 @@ export class ParamsParser {
       if (arg === '--version' || arg === '-v') result.version = true;
     }
 
+    // configオプションは無視
+
     return result;
   }
 
@@ -150,10 +152,13 @@ export class ParamsParser {
       };
     }
 
+    // configオプションを無視
+    const { configFile, ...validOptions } = options;
+
     return {
       type: 'single',
       command: 'init',
-      options,
+      options: validOptions,
     };
   }
 
@@ -338,7 +343,8 @@ export class ParamsParser {
         arg === '--from' ||
         arg === '--destination' ||
         arg === '--input' ||
-        arg === '--adaptation'
+        arg === '--adaptation' ||
+        arg === '--config'
       ) {
         if (arg === '--from') options.fromFile = nextArg;
         if (arg === '--destination') options.destinationFile = nextArg;
@@ -356,6 +362,9 @@ export class ParamsParser {
             };
           }
           options.adaptationType = nextArg;
+        }
+        if (arg === '--config') {
+          options.configFile = nextArg;
         }
         i++;
       }
@@ -388,6 +397,9 @@ export class ParamsParser {
           };
         }
         options.adaptationType = nextArg;
+        i++;
+      } else if (arg === '-c' && !options.configFile) {
+        options.configFile = nextArg;
         i++;
       }
     }

--- a/src/params_parser.ts
+++ b/src/params_parser.ts
@@ -153,7 +153,7 @@ export class ParamsParser {
     }
 
     // configオプションを無視
-    const { configFile, ...validOptions } = options;
+    const { configFile: _configFile, ...validOptions } = options;
 
     return {
       type: 'single',

--- a/src/types.ts
+++ b/src/types.ts
@@ -68,6 +68,8 @@ export interface OptionParams {
   fromLayerType?: LayerType;
   /** The prompt adaptation type when specified with --adaptation or -a */
   adaptationType?: string;
+  /** The configuration file name when specified with --config or -c */
+  configFile?: string;
 }
 
 /**

--- a/tests/03_unit/01_options_test.ts
+++ b/tests/03_unit/01_options_test.ts
@@ -1,26 +1,30 @@
 /**
- * オプションのテストスイート
+ * Option Test Suite
  *
- * このテストファイルの目的：
- * 1. オプションの長形式と短形式が正しく処理されることを確認
- * 2. オプションの組み合わせが正しく動作することを検証
- * 3. オプションの優先順位が正しく適用されることを確認
+ * Purpose of this test file:
+ * 1. Verify that long and short form options are handled correctly
+ * 2. Validate that option combinations work as expected
+ * 3. Confirm that option precedence is applied correctly
+ * 4. Confirm that the config option is only available with DoubleParams
  *
- * 期待される動作：
- * - 長形式のオプション（--from, --destination, --input）が正しく処理される
- * - 短形式のオプション（-f, -o, -i）が正しく処理される
- * - 長形式が短形式より優先される
- * - オプションの組み合わせが正しく処理される
+ * Expected behavior:
+ * - Long form options (--from, --destination, --input, --config) are handled correctly
+ * - Short form options (-f, -o, -i, -c) are handled correctly
+ * - Long form takes precedence over short form
+ * - Option combinations are handled correctly
+ * - The config option is only valid with DoubleParams
  *
- * テストケースの構成：
- * 1. 長形式オプションのテスト
- * 2. 短形式オプションのテスト
- * 3. オプションの組み合わせテスト
- * 4. オプションの優先順位テスト
+ * Test case structure:
+ * 1. Test long form options
+ * 2. Test short form options
+ * 3. Test option combinations
+ * 4. Test option precedence
+ * 5. Test config option constraints
  *
- * 注意事項：
- * - オプションの順序は結果に影響しない
- * - 同じオプションが複数回指定された場合、最後の指定が有効
+ * Notes:
+ * - The order of options does not affect the result
+ * - If the same option is specified multiple times, the last one is valid
+ * - The config option is only available with DoubleParams
  */
 
 import { assertEquals } from '@std/assert';
@@ -127,6 +131,84 @@ Deno.test('Options', async (t) => {
         fromFile: 'long.txt',
         destinationFile: 'long.txt',
         fromLayerType: 'project',
+      });
+    }
+  });
+
+  await t.step('should handle config option in DoubleParams', () => {
+    const result = parser.parse([
+      'to',
+      'project',
+      '--config',
+      'test',
+    ]);
+    assertEquals(result.type, 'double');
+    if (result.type === 'double') {
+      assertEquals(result.demonstrativeType, 'to');
+      assertEquals(result.layerType, 'project');
+      assertEquals(result.options, {
+        configFile: 'test',
+      });
+    }
+  });
+
+  await t.step('should handle config option with short form', () => {
+    const result = parser.parse([
+      'to',
+      'project',
+      '-c',
+      'test',
+    ]);
+    assertEquals(result.type, 'double');
+    if (result.type === 'double') {
+      assertEquals(result.demonstrativeType, 'to');
+      assertEquals(result.layerType, 'project');
+      assertEquals(result.options, {
+        configFile: 'test',
+      });
+    }
+  });
+
+  await t.step('should ignore config option in NoParams', () => {
+    const result = parser.parse([
+      '--config',
+      'test',
+    ]);
+    assertEquals(result.type, 'no-params');
+    if (result.type === 'no-params') {
+      assertEquals(result.help, false);
+      assertEquals(result.version, false);
+    }
+  });
+
+  await t.step('should ignore config option in SingleParam', () => {
+    const result = parser.parse([
+      'init',
+      '--config',
+      'test',
+    ]);
+    assertEquals(result.type, 'single');
+    if (result.type === 'single') {
+      assertEquals(result.command, 'init');
+      assertEquals(result.options, {});
+    }
+  });
+
+  await t.step('should prioritize long form config over short form', () => {
+    const result = parser.parse([
+      'to',
+      'project',
+      '--config',
+      'long',
+      '-c',
+      'short',
+    ]);
+    assertEquals(result.type, 'double');
+    if (result.type === 'double') {
+      assertEquals(result.demonstrativeType, 'to');
+      assertEquals(result.layerType, 'project');
+      assertEquals(result.options, {
+        configFile: 'long',
       });
     }
   });


### PR DESCRIPTION
# Add --config option for DoubleParams

This PR adds a new `--config` / `-c` option that allows users to specify a configuration file name when using DoubleParams.

## Changes

1. **New Option Implementation**
   - Added `--config` / `-c` option to specify configuration file name
   - Option is only available with DoubleParams
   - Option is ignored in NoParams and SingleParam modes

2. **Type System Updates**
   - Added `configFile` property to `OptionParams` interface
   - Updated type definitions to support the new option

3. **Documentation**
   - Added option specification to `docs/options.ja.md`
   - Added option to glossary in `docs/glossary.ja.md`
   - Added usage examples to `docs/params.ja.md`
   - Added new example file `examples/config_usage.ts`
   - Updated `examples/README.md` with config option examples

4. **Testing**
   - Added test cases for config option in `tests/03_unit/01_options_test.ts`
   - Translated test comments to English for better maintainability
   - Added tests for:
     - Long and short form options
     - Option precedence
     - Option behavior in different modes

5. **Code Quality**
   - Fixed formatting issues
   - Fixed linter warnings
   - Improved code organization

## Testing

The changes have been tested with:
- Unit tests for all new functionality
- Example usage in different scenarios
- CI checks (format, lint, test)

## Related Issues

This PR implements the feature requested in #4, which allows users to specify different configuration files (e.g., `--config test` will load `./.agent/breakdown/config/test.yml`). This enables users to maintain multiple configurations and switch between them easily, particularly useful for different installation names like `testprompt`, `gitprompt`, etc.

Closes #4 