### PR TITLE
feat(params-parser): make optionRule parameter optional with default value

### DIFF
--- a/src/parser/params_parser.ts
+++ b/src/parser/params_parser.ts
@@ -12,12 +12,31 @@ import { OneParamValidator } from '../validator/one_param_validator.ts';
 import { TwoParamValidator } from '../validator/two_param_validator.ts';
 
 /**
+ * デフォルトのオプションルール
+ */
+const DEFAULT_OPTION_RULE: OptionRule = {
+  format: '--key=value',
+  validation: {
+    customVariables: ['uv-project', 'uv-version', 'uv-environment'],
+    emptyValue: 'error',
+    unknownOption: 'error',
+    duplicateOption: 'error',
+    requiredOptions: [],
+    valueTypes: ['string'],
+  },
+  flagOptions: {
+    help: 'help',
+    version: 'version',
+  },
+};
+
+/**
  * パラメータパーサー
  */
 export class ParamsParser {
   private optionRule: OptionRule;
 
-  constructor(optionRule: OptionRule) {
+  constructor(optionRule: OptionRule = DEFAULT_OPTION_RULE) {
     this.optionRule = optionRule;
   }
 

--- a/tests/0_architecture/architecture_params_parser_test.ts
+++ b/tests/0_architecture/architecture_params_parser_test.ts
@@ -27,3 +27,11 @@ Deno.test('test_params_parser_constructor', () => {
   const parser = new ParamsParser(optionRule);
   assertEquals(parser instanceof ParamsParser, true);
 });
+
+Deno.test('test_params_parser_default_option_rule', () => {
+  const parser = new ParamsParser();
+  assertEquals(parser instanceof ParamsParser, true);
+  const result = parser.parse(['--help']);
+  assertEquals(result.type, 'zero');
+  assertEquals(result.options.help, '');
+});

--- a/tests/1_structures/structure_params_parser_test.ts
+++ b/tests/1_structures/structure_params_parser_test.ts
@@ -1,0 +1,38 @@
+import { assertEquals } from 'https://deno.land/std/testing/asserts.ts';
+import { ParamsParser } from '../../src/parser/params_parser.ts';
+import { OptionRule } from '../../src/result/types.ts';
+
+const optionRule: OptionRule = {
+  format: '--key=value',
+  validation: {
+    customVariables: ['uv-project', 'uv-version', 'uv-environment'],
+    emptyValue: 'error',
+    unknownOption: 'error',
+    duplicateOption: 'error',
+    requiredOptions: [],
+    valueTypes: ['string'],
+  },
+  flagOptions: {
+    help: 'help',
+    version: 'version',
+  },
+};
+
+Deno.test('test_params_parser_structure', () => {
+  const parser = new ParamsParser(optionRule);
+  assertEquals(typeof parser.parse, 'function');
+  assertEquals(parser instanceof ParamsParser, true);
+});
+
+Deno.test('test_params_parser_default_structure', () => {
+  const parser = new ParamsParser();
+  assertEquals(typeof parser.parse, 'function');
+  assertEquals(parser instanceof ParamsParser, true);
+
+  // Test default option rule structure
+  const result = parser.parse(['--help']);
+  assertEquals(result.type, 'zero');
+  assertEquals(Array.isArray(result.params), true);
+  assertEquals(typeof result.options, 'object');
+  assertEquals(result.options.help, '');
+});


### PR DESCRIPTION
## Changes\n\n- Add DEFAULT_OPTION_RULE constant with standard configuration\n- Make optionRule parameter optional in ParamsParser constructor\n- Add architecture and structure tests for default option rule\n- Verify default option rule functionality with help command\n\n## Testing\n\nAll tests passed including architecture and structure tests.\n\n## Related Issues\n\nCloses #123