### PR TITLE
refactor: update flag option value to undefined

### DIFF
--- a/drafts/2025/20250603-arch-rebuild.ja.md
+++ b/drafts/2025/20250603-arch-rebuild.ja.md
@@ -1,8 +1,8 @@
 設計の方針を docs/architecture/ 配下へまとめてある。
-今回、Option処理について追記した。この変更差分を調べ、実装に反映したい。
+今回、FlagOption処理について別の補足ファイルを作成した。この修正内容を把握し、実装に反映したい。
 
-差分:
-docs/architecture/ を diff して、差分を把握して。
+修正内容:
+tmp/flag_options.ja.md の修正が該当する。
 オプションの詳細は、 docs/options.ja.md や用語集を見て欲しい。
 
 

--- a/src/parser/params_parser.ts
+++ b/src/parser/params_parser.ts
@@ -83,7 +83,10 @@ export class ParamsParser {
         const [key, value] = arg.split('=');
         const normalizedKey = key.replace(/^--/, '');
         console.log('[DEBUG] processing option:', { arg, key, normalizedKey, value });
-        options[normalizedKey] = value || '';
+        // Only set value for non-flag options
+        if (!this.optionRule.flagOptions[normalizedKey]) {
+          options[normalizedKey] = value || '';
+        }
       } else {
         console.log('[DEBUG] processing param:', arg);
         params.push(arg);

--- a/src/parser/params_parser.ts
+++ b/src/parser/params_parser.ts
@@ -75,7 +75,7 @@ export class ParamsParser {
     }
 
     // Extract options from validated params
-    const options: Record<string, string> = {};
+    const options: Record<string, string | undefined> = {};
     const params: string[] = [];
     console.log('[DEBUG] validatedParams:', optionsResult.validatedParams);
     for (const arg of optionsResult.validatedParams) {
@@ -83,8 +83,10 @@ export class ParamsParser {
         const [key, value] = arg.split('=');
         const normalizedKey = key.replace(/^--/, '');
         console.log('[DEBUG] processing option:', { arg, key, normalizedKey, value });
-        // Only set value for non-flag options
-        if (!this.optionRule.flagOptions[normalizedKey]) {
+        // Set flag options in options object with undefined value
+        if (this.optionRule.flagOptions[normalizedKey]) {
+          options[normalizedKey] = undefined;
+        } else {
           options[normalizedKey] = value || '';
         }
       } else {

--- a/src/result/types.ts
+++ b/src/result/types.ts
@@ -4,7 +4,7 @@
 export interface ParamsResult {
   type: 'zero' | 'one' | 'two' | 'error';
   params: string[];
-  options: Record<string, string>;
+  options: Record<string, string | undefined>;
   error?: ErrorInfo;
 }
 

--- a/tests/0_architecture/architecture_params_parser_test.ts
+++ b/tests/0_architecture/architecture_params_parser_test.ts
@@ -33,5 +33,5 @@ Deno.test('test_params_parser_default_option_rule', () => {
   assertEquals(parser instanceof ParamsParser, true);
   const result = parser.parse(['--help']);
   assertEquals(result.type, 'zero');
-  assertEquals(result.options.help, '');
+  assertEquals(result.options.help, undefined, 'Flag option should be undefined');
 });

--- a/tests/1_structures/structure_params_parser_test.ts
+++ b/tests/1_structures/structure_params_parser_test.ts
@@ -34,5 +34,5 @@ Deno.test('test_params_parser_default_structure', () => {
   assertEquals(result.type, 'zero');
   assertEquals(Array.isArray(result.params), true);
   assertEquals(typeof result.options, 'object');
-  assertEquals(result.options.help, '');
+  assertEquals(result.options.help, undefined, 'Flag option should be undefined');
 });

--- a/tests/2_impliments/1_cores/impl_params_parser_test.ts
+++ b/tests/2_impliments/1_cores/impl_params_parser_test.ts
@@ -26,7 +26,11 @@ Deno.test('test_params_parser_implementation', () => {
   const optionsOnlyResult = parser.parse(optionsOnlyArgs);
   assertEquals(optionsOnlyResult.type, 'zero', 'Options only should be zero type');
   assertEquals(optionsOnlyResult.params, [], 'Params should be empty for options only');
-  assertEquals(optionsOnlyResult.options, { help: '', version: '' }, 'Options should match');
+  assertEquals(
+    optionsOnlyResult.options,
+    { help: undefined, version: undefined },
+    'Options should match',
+  );
 
   // 1つの引数のテスト
   const oneParamArgs = ['init'];
@@ -56,7 +60,7 @@ Deno.test('test_params_parser_implementation', () => {
   assertEquals(twoParamWithOptionsResult.params, ['to', 'project'], 'Params should match');
   assertEquals(
     twoParamWithOptionsResult.options,
-    { help: '', version: '' },
+    { help: undefined, version: undefined },
     'Options should match',
   );
   assertEquals(

--- a/tests/2_impliments/2_units/unit_params_parser_test.ts
+++ b/tests/2_impliments/2_units/unit_params_parser_test.ts
@@ -26,7 +26,11 @@ Deno.test('test_params_parser_unit', () => {
   console.log('[DEBUG] optionsOnlyResult:', optionsOnlyResult);
   assertEquals(optionsOnlyResult.type, 'zero', 'Options only should be zero type');
   assertEquals(optionsOnlyResult.params, [], 'Params should be empty for options only');
-  assertEquals(optionsOnlyResult.options, { help: '', version: '' }, 'Options should match');
+  assertEquals(
+    optionsOnlyResult.options,
+    { help: undefined, version: undefined },
+    'Options should match',
+  );
 
   // 1つの引数のテスト
   const oneParamResult = parser.parse(['init']) as OneParamResult;
@@ -61,7 +65,7 @@ Deno.test('test_params_parser_unit', () => {
   assertEquals(twoParamWithOptionsResult.params, ['to', 'project'], 'Params should match input');
   assertEquals(
     twoParamWithOptionsResult.options,
-    { help: '', version: '' },
+    { help: undefined, version: undefined },
     'Options should match',
   );
   assertEquals(

--- a/tests/2_impliments/3_integrations/integration_parser_validator_test.ts
+++ b/tests/2_impliments/3_integrations/integration_parser_validator_test.ts
@@ -95,7 +95,7 @@ Deno.test('test_parser_validator_integration', () => {
   const zeroParamsParseResult = parser.parse(['--help']);
   assertEquals(zeroParamsParseResult.type, 'zero', 'Should parse as zero params');
   assertEquals(zeroParamsParseResult.params, [], 'Should have empty params');
-  assertEquals(zeroParamsParseResult.options.help, '', 'Should have help option');
+  assertEquals(zeroParamsParseResult.options.help, undefined, 'Should have help option without value');
 
   // 2. 1パラメータケース
   const oneParamParseResult = parser.parse(['init']);
@@ -117,6 +117,22 @@ Deno.test('test_parser_validator_integration', () => {
   const complexParseResult = parser.parse(['to', 'project', '--help', '--version']);
   assertEquals(complexParseResult.type, 'two', 'Should parse as two params with options');
   assertEquals(complexParseResult.params.length, 2, 'Should include only parameters');
-  assertEquals(complexParseResult.options.help, '', 'Should have help option');
-  assertEquals(complexParseResult.options.version, '', 'Should have version option');
+  assertEquals(complexParseResult.options.help, undefined, 'Should have help option without value');
+  assertEquals(complexParseResult.options.version, undefined, 'Should have version option without value');
+});
+
+Deno.test('flag option with value should return error (--help=true)', () => {
+  const parser = new ParamsParser(optionRule);
+  const result = parser.parse(['--help=true']);
+  assertEquals(result.type, 'error');
+  assertEquals(result.error?.message, 'Invalid option format: --help=true, Unknown option: help=true');
+  assertEquals(result.error?.category, 'invalid_format');
+});
+
+Deno.test('flag option with value should return error (--version=true)', () => {
+  const parser = new ParamsParser(optionRule);
+  const result = parser.parse(['--version=true']);
+  assertEquals(result.type, 'error');
+  assertEquals(result.error?.message, 'Invalid option format: --version=true, Unknown option: version=true');
+  assertEquals(result.error?.category, 'invalid_format');
 });

--- a/tests/2_impliments/3_integrations/integration_parser_validator_test.ts
+++ b/tests/2_impliments/3_integrations/integration_parser_validator_test.ts
@@ -95,7 +95,11 @@ Deno.test('test_parser_validator_integration', () => {
   const zeroParamsParseResult = parser.parse(['--help']);
   assertEquals(zeroParamsParseResult.type, 'zero', 'Should parse as zero params');
   assertEquals(zeroParamsParseResult.params, [], 'Should have empty params');
-  assertEquals(zeroParamsParseResult.options.help, undefined, 'Should have help option without value');
+  assertEquals(
+    zeroParamsParseResult.options.help,
+    undefined,
+    'Should have help option without value',
+  );
 
   // 2. 1パラメータケース
   const oneParamParseResult = parser.parse(['init']);
@@ -118,14 +122,21 @@ Deno.test('test_parser_validator_integration', () => {
   assertEquals(complexParseResult.type, 'two', 'Should parse as two params with options');
   assertEquals(complexParseResult.params.length, 2, 'Should include only parameters');
   assertEquals(complexParseResult.options.help, undefined, 'Should have help option without value');
-  assertEquals(complexParseResult.options.version, undefined, 'Should have version option without value');
+  assertEquals(
+    complexParseResult.options.version,
+    undefined,
+    'Should have version option without value',
+  );
 });
 
 Deno.test('flag option with value should return error (--help=true)', () => {
   const parser = new ParamsParser(optionRule);
   const result = parser.parse(['--help=true']);
   assertEquals(result.type, 'error');
-  assertEquals(result.error?.message, 'Invalid option format: --help=true, Unknown option: help=true');
+  assertEquals(
+    result.error?.message,
+    'Invalid option format: --help=true, Unknown option: help=true',
+  );
   assertEquals(result.error?.category, 'invalid_format');
 });
 
@@ -133,6 +144,9 @@ Deno.test('flag option with value should return error (--version=true)', () => {
   const parser = new ParamsParser(optionRule);
   const result = parser.parse(['--version=true']);
   assertEquals(result.type, 'error');
-  assertEquals(result.error?.message, 'Invalid option format: --version=true, Unknown option: version=true');
+  assertEquals(
+    result.error?.message,
+    'Invalid option format: --version=true, Unknown option: version=true',
+  );
   assertEquals(result.error?.category, 'invalid_format');
 });

--- a/tests/2_impliments/4_e2e/e2e_params_parser_test.ts
+++ b/tests/2_impliments/4_e2e/e2e_params_parser_test.ts
@@ -25,13 +25,13 @@ Deno.test('test_params_parser_e2e', () => {
   const helpResult = parser.parse(['--help']);
   assertEquals(helpResult.type, 'zero', 'Help command should return zero params result');
   assertEquals(helpResult.params, [], 'Help command should be empty params');
-  assertEquals(helpResult.options.help, '', 'Help option should be present');
+  assertEquals(helpResult.options.help, undefined, 'Help option should be present');
 
   // バージョンコマンドのテスト
   const versionResult = parser.parse(['--version']);
   assertEquals(versionResult.type, 'zero', 'Version command should return zero params result');
   assertEquals(versionResult.params, [], 'Version command should be empty params');
-  assertEquals(versionResult.options.version, '', 'Version option should be present');
+  assertEquals(versionResult.options.version, undefined, 'Version option should be present');
 
   // initコマンドのテスト
   const initResult = parser.parse(['init']) as OneParamResult;


### PR DESCRIPTION
## Changes\n\n- Update ParamsResult interface to allow undefined values for flag options\n- Update all test files to expect undefined for flag options\n- Fix code formatting with deno fmt\n\n## Details\n\nThis PR updates the flag option validation behavior to:\n1. Set flag option values to undefined instead of empty string\n2. Update type definitions to support undefined values\n3. Update all test files to expect undefined values\n4. Fix code formatting issues\n\n## Testing\n\n- All tests pass\n- Code formatting is correct\n- Type checks pass