### PR TITLE
refactor: use default constructor in structure test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,10 @@ jobs:
           deno cache --reload mod.ts
 
       - name: Type Check
-        run: deno check mod.ts
+        run: |
+          deno check mod.ts
+          deno check "src/**/*.ts"
+          deno check "tests/**/*.ts"
 
       - name: JSR Type Check
         run: npx jsr publish --dry-run --allow-dirty

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,9 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: ${{ github.head_ref }}
 
       - name: Setup Deno
         uses: denoland/setup-deno@v1
@@ -29,6 +32,7 @@ jobs:
       - name: Cache Dependencies
         run: |
           rm -f deno.lock
+          git clean -fdx
           deno cache --reload mod.ts
 
       - name: Type Check


### PR DESCRIPTION
## Changes\n- Remove OptionRule from structure tests\n- Use default constructor in structure_option_rule_test.ts\n- Update CI workflow to handle cache properly\n\n## Why\n- Simplify tests by using default settings\n- Fix type errors in CI\n- Improve test maintainability